### PR TITLE
Fixed Javascript after migration, added in-browser-editor.

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -147,3 +147,4 @@ router.get('/customise', function (req, res) {
 	res.redirect(`/v02-1/choosewarnings/overview-flood`)
 })
 
+require('@x-govuk/edit-prototype-in-browser').addRoutes(require('govuk-prototype-kit').requests)

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,14 +1,3 @@
 <!-- Javascript -->
-<script src="/public/javascripts/jquery-1.11.3.js"></script>
+{% include "govuk-prototype-kit/includes/scripts.html" %}
 <script src='https://api.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.js'></script>
-
-{% for scriptUrl in extensionConfig.scripts %}
-<script src="{{scriptUrl}}"></script>
-{% endfor %}
-
-<script src="/public/javascripts/application.js"></script>
-
-{% if useAutoStoreData %}
-<script src="/public/javascripts/auto-store-data.js"></script>
-
-{% endif %}


### PR DESCRIPTION
We discussed the in-browser editor, I wasn't sure why it wasn't working.  This was because there was a problem with the javascript includes.  This change fixes that and adds the in browser editor.  If you don't want the editor anymore you'll need to remove the line I've put into `app/routes.js` and uninstall the plugin (this can be done in the browser).